### PR TITLE
fix: keep timestamp logic on parse errors

### DIFF
--- a/.github/workflows/douban_book.yml
+++ b/.github/workflows/douban_book.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 16 * * *"
+permissions:
+  contents: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -48,23 +50,29 @@ jobs:
         run: |
             heatmap "book"
       - name: push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
           ARTIFACT_BRANCH="heatmap-artifacts"
-          TMP_DIR="$(mktemp -d)"
-          mkdir -p "$TMP_DIR/OUT_FOLDER"
-          cp -R OUT_FOLDER/. "$TMP_DIR/OUT_FOLDER/" 2>/dev/null || true
-          git fetch origin "$ARTIFACT_BRANCH" || true
-          if git show-ref --verify --quiet "refs/remotes/origin/$ARTIFACT_BRANCH"; then
-            git switch -C "$ARTIFACT_BRANCH" "origin/$ARTIFACT_BRANCH"
+          WORK_DIR="$(mktemp -d)"
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --heads "$REPO_URL" "$ARTIFACT_BRANCH" >/dev/null 2>&1; then
+            git clone --depth 1 --branch "$ARTIFACT_BRANCH" "$REPO_URL" "$WORK_DIR/repo"
           else
-            git switch --orphan "$ARTIFACT_BRANCH"
+            git clone --depth 1 "$REPO_URL" "$WORK_DIR/repo"
+            cd "$WORK_DIR/repo"
+            git checkout --orphan "$ARTIFACT_BRANCH"
             git rm -rf . >/dev/null 2>&1 || true
+            cd - >/dev/null
           fi
-          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-          mkdir -p OUT_FOLDER
-          cp -R "$TMP_DIR/OUT_FOLDER/." OUT_FOLDER/
+
+          mkdir -p "$WORK_DIR/repo/OUT_FOLDER"
+          cp -R OUT_FOLDER/. "$WORK_DIR/repo/OUT_FOLDER/" 2>/dev/null || true
+
+          cd "$WORK_DIR/repo"
           git add OUT_FOLDER
           git commit -m 'update heatmap artifacts' || echo "nothing to commit"
-          git push origin "$ARTIFACT_BRANCH" || echo "nothing to push"
+          git push origin "HEAD:$ARTIFACT_BRANCH" || echo "nothing to push"

--- a/.github/workflows/douban_book.yml
+++ b/.github/workflows/douban_book.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -e .
       - name: douban book sync
         run: |
           douban "book"
@@ -50,7 +51,20 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
-          git commit -m 'add new heatmap' || echo "nothing to commit"
-          git pull --rebase origin main
-          git push || echo "nothing to push"
+          ARTIFACT_BRANCH="heatmap-artifacts"
+          TMP_DIR="$(mktemp -d)"
+          mkdir -p "$TMP_DIR/OUT_FOLDER"
+          cp -R OUT_FOLDER/. "$TMP_DIR/OUT_FOLDER/" 2>/dev/null || true
+          git fetch origin "$ARTIFACT_BRANCH" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$ARTIFACT_BRANCH"; then
+            git switch -C "$ARTIFACT_BRANCH" "origin/$ARTIFACT_BRANCH"
+          else
+            git switch --orphan "$ARTIFACT_BRANCH"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          mkdir -p OUT_FOLDER
+          cp -R "$TMP_DIR/OUT_FOLDER/." OUT_FOLDER/
+          git add OUT_FOLDER
+          git commit -m 'update heatmap artifacts' || echo "nothing to commit"
+          git push origin "$ARTIFACT_BRANCH" || echo "nothing to push"

--- a/.github/workflows/douban_book.yml
+++ b/.github/workflows/douban_book.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install -e .
+          pip install .
       - name: douban book sync
         run: |
           douban "book"

--- a/.github/workflows/douban_movie.yml
+++ b/.github/workflows/douban_movie.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -e .
       - name: douban movie sync
         run: |
           douban "movie"
@@ -50,7 +51,20 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
-          git commit -m 'add new heatmap' || echo "nothing to commit"
-          git pull --rebase origin main
-          git push || echo "nothing to push"
+          ARTIFACT_BRANCH="heatmap-artifacts"
+          TMP_DIR="$(mktemp -d)"
+          mkdir -p "$TMP_DIR/OUT_FOLDER"
+          cp -R OUT_FOLDER/. "$TMP_DIR/OUT_FOLDER/" 2>/dev/null || true
+          git fetch origin "$ARTIFACT_BRANCH" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$ARTIFACT_BRANCH"; then
+            git switch -C "$ARTIFACT_BRANCH" "origin/$ARTIFACT_BRANCH"
+          else
+            git switch --orphan "$ARTIFACT_BRANCH"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          mkdir -p OUT_FOLDER
+          cp -R "$TMP_DIR/OUT_FOLDER/." OUT_FOLDER/
+          git add OUT_FOLDER
+          git commit -m 'update heatmap artifacts' || echo "nothing to commit"
+          git push origin "$ARTIFACT_BRANCH" || echo "nothing to push"

--- a/.github/workflows/douban_movie.yml
+++ b/.github/workflows/douban_movie.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 16 * * *"
+permissions:
+  contents: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -48,23 +50,29 @@ jobs:
         run: |
             heatmap "movie"
       - name: push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
           ARTIFACT_BRANCH="heatmap-artifacts"
-          TMP_DIR="$(mktemp -d)"
-          mkdir -p "$TMP_DIR/OUT_FOLDER"
-          cp -R OUT_FOLDER/. "$TMP_DIR/OUT_FOLDER/" 2>/dev/null || true
-          git fetch origin "$ARTIFACT_BRANCH" || true
-          if git show-ref --verify --quiet "refs/remotes/origin/$ARTIFACT_BRANCH"; then
-            git switch -C "$ARTIFACT_BRANCH" "origin/$ARTIFACT_BRANCH"
+          WORK_DIR="$(mktemp -d)"
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --heads "$REPO_URL" "$ARTIFACT_BRANCH" >/dev/null 2>&1; then
+            git clone --depth 1 --branch "$ARTIFACT_BRANCH" "$REPO_URL" "$WORK_DIR/repo"
           else
-            git switch --orphan "$ARTIFACT_BRANCH"
+            git clone --depth 1 "$REPO_URL" "$WORK_DIR/repo"
+            cd "$WORK_DIR/repo"
+            git checkout --orphan "$ARTIFACT_BRANCH"
             git rm -rf . >/dev/null 2>&1 || true
+            cd - >/dev/null
           fi
-          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-          mkdir -p OUT_FOLDER
-          cp -R "$TMP_DIR/OUT_FOLDER/." OUT_FOLDER/
+
+          mkdir -p "$WORK_DIR/repo/OUT_FOLDER"
+          cp -R OUT_FOLDER/. "$WORK_DIR/repo/OUT_FOLDER/" 2>/dev/null || true
+
+          cd "$WORK_DIR/repo"
           git add OUT_FOLDER
           git commit -m 'update heatmap artifacts' || echo "nothing to commit"
-          git push origin "$ARTIFACT_BRANCH" || echo "nothing to push"
+          git push origin "HEAD:$ARTIFACT_BRANCH" || echo "nothing to push"

--- a/.github/workflows/douban_movie.yml
+++ b/.github/workflows/douban_movie.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install -e .
+          pip install .
       - name: douban movie sync
         run: |
           douban "movie"

--- a/douban2notion/utils.py
+++ b/douban2notion/utils.py
@@ -331,12 +331,17 @@ def transform_id(book_id):
 def get_weread_url(book_id):
     return f"https://weread.qq.com/web/reader/{calculate_book_str_id(book_id)}"
 
-def str_to_timestamp(date):
-    if date == None:
+def str_to_timestamp(date_str):
+    if not date_str:
         return 0
-    dt = pendulum.parse(date)
-    # 获取时间戳
-    return int(dt.timestamp())
+
+    try:
+        dt = pendulum.parse(date_str)
+        # 获取时间戳
+        return int(dt.timestamp())
+    except Exception as e:
+        print(f"⚠️  无法解析日期 '{date_str}': {type(e).__name__}")
+        return 0
 
 upload_url = 'https://wereadassets.malinkang.com/'
 


### PR DESCRIPTION
## Summary
- Keep original timestamp return type while handling parse errors
- Return 0 when input is empty or unparseable, and log a warning

## Testing
- Not run (not provided)